### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,7 @@ enabled_site_setting :discourse_chart_enabled
 
 register_asset "stylesheets/common/discourse-chart.scss"
 
-register_svg_icon "fas fa-chart-line"
+register_svg_icon "chart-line"
 
 after_initialize do
   on(:reduce_cooked) do |doc, post|


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.