### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: 3e5d7cb9a97e0229655fdb9924e3e229cccc0647
 < 3.4.0.beta1-dev: af5ea31e0ddcb32a1d4f2d4812b66dd00de82b78
 < 3.3.0.beta1-dev: 59ad8a400acedfcecddcb36b1a12c10411c7f9ff
 < 3.2.0.beta2: 70871d4c1b013c6414a0331ebb4d97512c1ffc81

--- a/assets/javascripts/discourse/components/modal/chart-ui-builder.gjs
+++ b/assets/javascripts/discourse/components/modal/chart-ui-builder.gjs
@@ -131,7 +131,7 @@ export default class ChartUiBuilder extends Component {
                   {{on "input" this.setDisabled}}
                 />
                 <DButton @icon="plus" @action={{this.addRow}} />
-                <DButton @icon="trash-alt" @action={{fn this.removeRow row}} />
+                <DButton @icon="trash-can" @action={{fn this.removeRow row}} />
               </div>
             {{/each}}
           </div>


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.