### PR TITLE
FEATURE: Show charts in the rich editor

### DIFF
--- a/assets/javascripts/discourse-markdown/discourse-chart.js
+++ b/assets/javascripts/discourse-markdown/discourse-chart.js
@@ -55,40 +55,49 @@ export function setup(helper) {
 
   helper.allowList([
     "div.discourse-chart",
-    "div.discourse-chart.is-loading",
-    "div.discourse-chart.is-building",
+    "div[class=discourse-chart is-building is-loading]",
+    "div[data-type]",
+    "div[data-labels]",
+    "div[data-title]",
+    "div[data-x-axis-title]",
+    "div[data-y-axis-title]",
+    "div[data-border-colors]",
+    "div[data-background-colors]",
   ]);
 
   helper.registerPlugin((md) => {
-    md.inline.bbcode.ruler.push("discourse-chart", {
+    md.block.bbcode.ruler.push("discourse-chart", {
       tag: "chart",
 
       replace(state, tagInfo, content) {
-        const token = state.push("html_raw", "", 0);
-
-        content = content
-          .split("\n")
-          .filter(Boolean)
-          .map((x) => state.md.utils.escapeHtml(x))
-          .join("\n");
+        const token = state.push("discourse_chart", "div", 0);
+        token.block = true;
+        token.content = content.split("\n").filter(Boolean).join("\n");
 
         const attributes = processAttributes(
           tagInfo.attrs,
           state.md.utils.escapeHtml
         );
-
-        const formattedAttributes = [];
-        Object.keys(attributes).forEach((attribute) => {
-          const value = attributes[attribute];
-          formattedAttributes.push(`data-${attribute}="${value}"`);
-        });
-
-        token.content = `<div class="discourse-chart is-building is-loading" ${formattedAttributes.join(
-          " "
-        )}>${content}</div>\n`;
+        token.attrs = Object.entries(attributes).map(([name, value]) => [
+          `data-${name}`,
+          value,
+        ]);
 
         return true;
       },
     });
+
+    // a single token keeps the chart data out of the token stream as text, so
+    // the rich editor can hold it as an attribute of one leaf node
+    md.renderer.rules.discourse_chart = (tokens, idx) => {
+      const token = tokens[idx];
+      const attributes = token.attrs
+        .map(([name, value]) => `${name}="${value}"`)
+        .join(" ");
+
+      return `<div class="discourse-chart is-building is-loading" ${attributes}>${md.utils.escapeHtml(
+        token.content
+      )}</div>\n`;
+    };
   });
 }

--- a/assets/javascripts/discourse-markdown/discourse-chart.js
+++ b/assets/javascripts/discourse-markdown/discourse-chart.js
@@ -6,39 +6,41 @@ const SUPPORTED_CHART_TYPES = [
   "horizontalBar",
 ];
 
-function processAttributes(attrs, escapeHtml) {
+// values are kept as the author wrote them; escaping belongs to the renderer,
+// as anything reading the token back (the rich editor) needs the original
+function processAttributes(attrs) {
   const attributes = {};
 
   const inputType = attrs.type;
 
   if (inputType && SUPPORTED_CHART_TYPES.includes(inputType)) {
-    attributes["type"] = escapeHtml(inputType);
+    attributes["type"] = inputType;
   } else {
     attributes["type"] = SUPPORTED_CHART_TYPES[0];
   }
 
   if (attrs["borderColors"]) {
-    attributes["border-colors"] = escapeHtml(attrs["borderColors"]);
+    attributes["border-colors"] = attrs["borderColors"];
   }
 
   if (attrs["backgroundColors"]) {
-    attributes["background-colors"] = escapeHtml(attrs["backgroundColors"]);
+    attributes["background-colors"] = attrs["backgroundColors"];
   }
 
   if (attrs["xAxisTitle"]) {
-    attributes["x-axis-title"] = escapeHtml(attrs["xAxisTitle"]);
+    attributes["x-axis-title"] = attrs["xAxisTitle"];
   }
 
   if (attrs["yAxisTitle"]) {
-    attributes["y-axis-title"] = escapeHtml(attrs["yAxisTitle"]);
+    attributes["y-axis-title"] = attrs["yAxisTitle"];
   }
 
   if (attrs["title"]) {
-    attributes["title"] = escapeHtml(attrs["title"]);
+    attributes["title"] = attrs["title"];
   }
 
   if (attrs["labels"]) {
-    attributes["labels"] = escapeHtml(attrs["labels"]);
+    attributes["labels"] = attrs["labels"];
   }
 
   return attributes;
@@ -66,6 +68,12 @@ export function setup(helper) {
   ]);
 
   helper.registerPlugin((md) => {
+    // the rule's name does not match the feature's, so it is never disabled
+    // along with it
+    if (!md.options.discourse.features.discourse_chart) {
+      return;
+    }
+
     md.block.bbcode.ruler.push("discourse-chart", {
       tag: "chart",
 
@@ -74,10 +82,7 @@ export function setup(helper) {
         token.block = true;
         token.content = content.split("\n").filter(Boolean).join("\n");
 
-        const attributes = processAttributes(
-          tagInfo.attrs,
-          state.md.utils.escapeHtml
-        );
+        const attributes = processAttributes(tagInfo.attrs);
         token.attrs = Object.entries(attributes).map(([name, value]) => [
           `data-${name}`,
           value,
@@ -92,7 +97,7 @@ export function setup(helper) {
     md.renderer.rules.discourse_chart = (tokens, idx) => {
       const token = tokens[idx];
       const attributes = token.attrs
-        .map(([name, value]) => `${name}="${value}"`)
+        .map(([name, value]) => `${name}="${md.utils.escapeHtml(value)}"`)
         .join(" ");
 
       return `<div class="discourse-chart is-building is-loading" ${attributes}>${md.utils.escapeHtml(

--- a/assets/javascripts/discourse/components/chart-preview.gjs
+++ b/assets/javascripts/discourse/components/chart-preview.gjs
@@ -2,12 +2,38 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import loadChartJS from "discourse/lib/load-chart-js";
 import chart from "../../initializers/discourse-chart";
 
 export default class ChartPreview extends Component {
+  #element;
+  #Chart;
+
+  // the source can change again while the library is still loading, and the
+  // renders would then land out of order; only the newest one may draw
+  #renderId = 0;
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+
+    this.#renderId++;
+    this.#destroyChart();
+  }
+
   @action
-  renderChart(element) {
-    // the renderer consumes the container, so it is rebuilt on every change
+  async renderChart(element) {
+    this.#element = element;
+    const renderId = ++this.#renderId;
+
+    this.#Chart ??= await loadChartJS();
+
+    if (renderId !== this.#renderId) {
+      return;
+    }
+
+    // the renderer consumes the container, so it is rebuilt on every change,
+    // taking the chart drawn into the previous canvas with it
+    this.#destroyChart();
     element.className = "discourse-chart is-building is-loading";
     element.textContent = this.args.source;
 
@@ -15,7 +41,15 @@ export default class ChartPreview extends Component {
       element.dataset[name] = value;
     }
 
-    chart.renderCharts([element]);
+    chart.renderChart(element, this.#Chart);
+  }
+
+  #destroyChart() {
+    const canvas = this.#element?.querySelector("canvas");
+
+    if (canvas) {
+      this.#Chart?.getChart(canvas)?.destroy();
+    }
   }
 
   <template>

--- a/assets/javascripts/discourse/components/chart-preview.gjs
+++ b/assets/javascripts/discourse/components/chart-preview.gjs
@@ -1,0 +1,27 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import chart from "../../initializers/discourse-chart";
+
+export default class ChartPreview extends Component {
+  @action
+  renderChart(element) {
+    // the renderer consumes the container, so it is rebuilt on every change
+    element.className = "discourse-chart is-building is-loading";
+    element.textContent = this.args.source;
+
+    for (const [name, value] of Object.entries(this.args.node.attrs.params)) {
+      element.dataset[name] = value;
+    }
+
+    chart.renderCharts([element]);
+  }
+
+  <template>
+    <div
+      {{didInsert this.renderChart}}
+      {{didUpdate this.renderChart @source}}
+    ></div>
+  </template>
+}

--- a/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -1,0 +1,99 @@
+import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import ChartPreview from "../components/chart-preview";
+
+const dashToCamelCase = (str) =>
+  str.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
+
+function toDataAttrs(params) {
+  const attrs = {};
+
+  for (const [name, value] of Object.entries(params)) {
+    attrs[`data-${name.replace(/([a-z])(?=[A-Z])/g, "$1-").toLowerCase()}`] =
+      value;
+  }
+
+  return attrs;
+}
+
+/** @type {import("discourse/lib/composer/rich-editor-extensions").RichEditorExtension} */
+const extension = {
+  nodeSpec: {
+    discourse_chart: {
+      attrs: { params: { default: {} } },
+      group: "block",
+      // isolating keeps the text around it from merging into the data
+      content: "preview_source",
+      // the node view owns the source, so the editor moves over the block as a
+      // unit rather than stepping into text it is not showing
+      atom: true,
+      defining: true,
+      isolating: true,
+      selectable: true,
+      createGapCursor: true,
+      parseDOM: [
+        {
+          tag: "div.discourse-chart",
+          getAttrs: (dom) => ({ params: { ...dom.dataset } }),
+        },
+      ],
+      toDOM: (node) => [
+        "div",
+        { class: "discourse-chart", ...toDataAttrs(node.attrs.params) },
+        0,
+      ],
+    },
+  },
+
+  nodeViews: {
+    discourse_chart: {
+      component: PreviewNodeView,
+      hasContent: true,
+      options: { preview: ChartPreview },
+    },
+  },
+
+  parse: {
+    discourse_chart: (state, token) => {
+      const params = {};
+      for (const [name, value] of token.attrs ?? []) {
+        params[dashToCamelCase(name.replace(/^data-/, ""))] = value;
+      }
+
+      state.openNode(state.schema.nodes.discourse_chart, { params });
+      state.openNode(state.schema.nodes.preview_source);
+      state.addText(token.content.trim());
+      state.closeNode();
+      state.closeNode();
+
+      return true;
+    },
+  },
+
+  inputRules: ({ schema }) => ({
+    match: /\[chart]$/,
+    handler: (state, match, start, end) => {
+      const chart = schema.nodes.discourse_chart.createAndFill(
+        { params: {} },
+        schema.nodes.preview_source.create()
+      );
+      const isAtStart = state.doc.resolve(start).parentOffset === 0;
+
+      return state.tr.replaceWith(isAtStart ? start - 1 : start, end, chart);
+    },
+  }),
+
+  serializeNode: {
+    discourse_chart(state, node) {
+      const params = Object.entries(node.attrs.params)
+        .map(([name, value]) => ` ${name}="${value}"`)
+        .join("");
+
+      state.write(`[chart${params}]\n`);
+      state.text(node.textContent, false);
+      state.write("\n[/chart]");
+      state.closeBlock(node);
+    },
+  },
+};
+
+export default extension;

--- a/assets/javascripts/discourse/lib/rich-editor-extension.js
+++ b/assets/javascripts/discourse/lib/rich-editor-extension.js
@@ -1,4 +1,8 @@
 import PreviewNodeView from "discourse/components/composer/preview-node-view";
+import {
+  previewSourceNode,
+  selectPreviewSource,
+} from "discourse/lib/composer/preview-block";
 import ChartPreview from "../components/chart-preview";
 
 const dashToCamelCase = (str) =>
@@ -34,6 +38,13 @@ const extension = {
         {
           tag: "div.discourse-chart",
           getAttrs: (dom) => ({ params: { ...dom.dataset } }),
+          // a cooked chart holds one row per line as plain text, which the
+          // parser would otherwise collapse into a single row
+          getContent: (dom, schema) =>
+            schema.nodes.discourse_chart.create(
+              null,
+              previewSourceNode(schema, dom.textContent)
+            ).content,
         },
       ],
       toDOM: (node) => [
@@ -69,23 +80,32 @@ const extension = {
     },
   },
 
-  inputRules: ({ schema }) => ({
+  inputRules: ({ schema, pmState: { TextSelection } }) => ({
     match: /\[chart]$/,
     handler: (state, match, start, end) => {
-      const chart = schema.nodes.discourse_chart.createAndFill(
+      const chart = schema.nodes.discourse_chart.create(
         { params: {} },
-        schema.nodes.preview_source.create()
+        previewSourceNode(schema, "")
       );
       const isAtStart = state.doc.resolve(start).parentOffset === 0;
+      const from = isAtStart ? start - 1 : start;
 
-      return state.tr.replaceWith(isAtStart ? start - 1 : start, end, chart);
+      return selectPreviewSource(
+        state.tr.replaceWith(from, end, chart),
+        TextSelection,
+        from
+      );
     },
   }),
 
   serializeNode: {
     discourse_chart(state, node) {
       const params = Object.entries(node.attrs.params)
-        .map(([name, value]) => ` ${name}="${value}"`)
+        // the bbcode tag has no escape for either character, so a value
+        // carrying one would end the attribute or the tag early
+        .map(
+          ([name, value]) => ` ${name}="${`${value}`.replace(/["\]]/g, "")}"`
+        )
         .join("");
 
       state.write(`[chart${params}]\n`);

--- a/assets/javascripts/initializers/add-chart-ui-builder.js
+++ b/assets/javascripts/initializers/add-chart-ui-builder.js
@@ -1,9 +1,12 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import ChartUiBuilder from "../discourse/components/modal/chart-ui-builder";
+import richEditorExtension from "../discourse/lib/rich-editor-extension";
 
 function initializeChartUIBuilder(api) {
   const siteSettings = api.container.lookup("service:site-settings");
   const modal = api.container.lookup("service:modal");
+
+  api.registerRichEditorExtension(richEditorExtension);
 
   api.addComposerToolbarPopupMenuOption({
     label: "chart.ui_builder.title",

--- a/spec/integration/chart_cooking_spec.rb
+++ b/spec/integration/chart_cooking_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe "Chart cooking" do
+  before { SiteSetting.discourse_chart_enabled = true }
+
+  it "emits a placeholder with the data and attributes for the client to render" do
+    post = Fabricate(:post, raw: <<~MD)
+        [chart type="bar" title="Sales" labels="a,b"]
+        | a | b
+        | 1 | 2
+        [/chart]
+      MD
+
+    expect(post.cooked).to include("discourse-chart is-building is-loading")
+    expect(post.cooked).to include('data-type="bar"')
+    expect(post.cooked).to include('data-title="Sales"')
+    expect(post.cooked).to include('data-labels="a,b"')
+    expect(post.cooked).to include("| a | b\n| 1 | 2")
+  end
+
+  it "escapes the data, and keeps an attribute inside its quotes" do
+    post = Fabricate(:post, raw: "[chart type=\"bar\" title=\"R&D <x>\"]\n| a & <b>\n[/chart]")
+
+    expect(post.cooked).to include("| a &amp; &lt;b&gt;")
+    # angle brackets are inert within a quoted value, and the sanitizer leaves
+    # them there; what matters is that the value cannot end the attribute
+    expect(post.cooked).to include('data-title="R&amp;D <x>"')
+    expect(post.cooked).not_to include("<x>>")
+  end
+
+  it "cannot be made to break out of an attribute" do
+    post =
+      Fabricate(:post, raw: "[chart type=\"bar\" title=\"a\\\" onerror=\\\"x\"]\n| a\n[/chart]")
+
+    expect(post.cooked).not_to include("onerror=\"x\"")
+  end
+
+  it "falls back to a supported type" do
+    post = Fabricate(:post, raw: "[chart type=\"bogus\"]\n| a\n[/chart]")
+
+    expect(post.cooked).to include('data-type="line"')
+    expect(post.cooked).not_to include("bogus")
+  end
+
+  it "renders a chart that follows a paragraph without a blank line" do
+    post = Fabricate(:post, raw: "Results:\n[chart type=\"bar\"]\n| a\n[/chart]")
+
+    expect(post.cooked).to include("<p>Results:</p>")
+    expect(post.cooked).to include("discourse-chart")
+  end
+
+  it "does not render when the plugin is disabled" do
+    SiteSetting.discourse_chart_enabled = false
+    post = Fabricate(:post, raw: "[chart type=\"bar\"]\n| a\n[/chart]")
+
+    expect(post.cooked).not_to include("discourse-chart")
+  end
+end

--- a/test/javascripts/integration/rich-editor-extension-test.js
+++ b/test/javascripts/integration/rich-editor-extension-test.js
@@ -58,5 +58,47 @@ module(
         `the chart data is untouched, got: ${editorClass.value}`
       );
     });
+
+    test("round-trips attribute values that have to be escaped in HTML", async function (assert) {
+      const chart = '[chart type="bar" title="R&D <x>"]\n1,2,3\n[/chart]';
+
+      await testMarkdown(
+        assert,
+        chart,
+        (a) => a.dom(".composer-preview-node").exists(),
+        chart
+      );
+    });
+
+    test("keeps the rows of a pasted chart", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "");
+      const { view } = editorClass;
+
+      view.pasteHTML(
+        '<div class="discourse-chart is-building is-loading" data-type="bar" data-title="T">| a | b\n| 1 | 2\n| 3 | 4</div>'
+      );
+
+      assert.strictEqual(
+        editorClass.value.trim(),
+        '[chart type="bar" title="T"]\n| a | b\n| 1 | 2\n| 3 | 4\n[/chart]',
+        "every row survives the round trip through cooked HTML"
+      );
+    });
+
+    test("puts the caret in the data of a chart it just inserted", async function (assert) {
+      const [editorClass] = await setupRichEditor(assert, "before");
+      const { view } = editorClass;
+
+      view.dispatch(view.state.tr.insertText("[chart"));
+      const pos = view.state.selection.from;
+      view.someProp("handleTextInput", (f) => f(view, pos, pos, "]"));
+
+      const { selection } = view.state;
+      assert.strictEqual(
+        selection.$head.parent.type.name,
+        "preview_source",
+        "typing carries on inside the new chart"
+      );
+    });
   }
 );

--- a/test/javascripts/integration/rich-editor-extension-test.js
+++ b/test/javascripts/integration/rich-editor-extension-test.js
@@ -1,0 +1,62 @@
+import { module, test } from "qunit";
+import {
+  registerRichEditorExtension,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  setupRichEditor,
+  testMarkdown,
+} from "discourse/tests/helpers/rich-editor-helper";
+import richEditorExtension from "discourse/plugins/discourse-chart/discourse/lib/rich-editor-extension";
+
+const CHART = '[chart type="bar" labels="a,b,c"]\n1,2,3\n[/chart]';
+
+module(
+  "Integration | Component | prosemirror-editor - chart extension",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.siteSettings.discourse_chart_enabled = true;
+
+      resetRichEditorExtensions().then(() => {
+        registerRichEditorExtension(richEditorExtension);
+      });
+    });
+
+    test("round-trips a chart", async function (assert) {
+      await testMarkdown(
+        assert,
+        CHART,
+        (a) => a.dom(".composer-preview-node").exists(),
+        CHART
+      );
+    });
+
+    test("keeps the data when the text around it is edited", async function (assert) {
+      const [editorClass] = await setupRichEditor(
+        assert,
+        `before\n\n${CHART}\n\nafter`
+      );
+      const { view } = editorClass;
+
+      let chartPos;
+      view.state.doc.descendants((node, pos) => {
+        if (node.type.name === "discourse_chart") {
+          chartPos = pos;
+        }
+      });
+
+      // delete across the chart's closing boundary, as backspacing at the start
+      // of the paragraph that follows it would
+      const boundary = chartPos + view.state.doc.nodeAt(chartPos).nodeSize;
+      view.dispatch(view.state.tr.delete(boundary, boundary + 1));
+
+      assert.true(
+        editorClass.value.includes(CHART),
+        `the chart data is untouched, got: ${editorClass.value}`
+      );
+    });
+  }
+);


### PR DESCRIPTION
Builds on core's preview block primitive (https://github.com/discourse/discourse/pull/42855) to render charts inline in the rich editor, with a control to show and edit the source rows.

The markdown rule now emits a structured token instead of raw HTML, with escaping applied only in the renderer — previously attributes were escaped during tokenization too, so every editor round-trip compounded the escaping (`R&D` → `R&amp;D` → …). The rule is also gated on the feature flag now: it registered under the name `discourse-chart` while the setting is `discourse_chart`, so the engine's name-based disabling never matched and `discourse_chart_enabled: false` never actually disabled cooking.

The preview component awaits the Chart.js loader, drops out-of-order renders, and destroys the previous Chart.js instance, fixing a leak of one instance per re-render.

Depends on discourse/discourse#42855 — the editor extension imports the shared preview block helpers from core.